### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/Volley/src/main/java/com/volley/air/error/VolleyErrorHelper.java
+++ b/Volley/src/main/java/com/volley/air/error/VolleyErrorHelper.java
@@ -12,6 +12,13 @@ import java.util.Map;
 import com.volley.air.base.NetworkResponse;
 
 public class VolleyErrorHelper {
+	
+	/**
+	 * Prevents class instantiation
+	 */
+	private VolleyErrorHelper() {
+	}
+
 	/**
 	 * 
 	 * @param error

--- a/Volley/src/main/java/com/volley/air/misc/IOUtils.java
+++ b/Volley/src/main/java/com/volley/air/misc/IOUtils.java
@@ -10,6 +10,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class IOUtils {
+    /**
+     * Prevents class instantiation
+     */
+    private IOUtils() {
+    }
     /*
      * Homebrewed simple serialization system used for reading and writing cache
      * headers on disk. Once upon a time, this used the standard Java

--- a/Volley/src/main/java/com/volley/air/misc/ImageUtils.java
+++ b/Volley/src/main/java/com/volley/air/misc/ImageUtils.java
@@ -30,7 +30,13 @@ public class ImageUtils {
 
     private static final String BASE64_URI_PREFIX = "base64,";
     private static final Pattern BASE64_IMAGE_URI_PATTERN = Pattern.compile("^(?:.*;)?base64,.*");
-    
+
+    /**
+     * Prevents class instantiation
+     */
+    private ImageUtils() {
+    }
+
     /**
      * Returns the largest power-of-two divisor for use in downscaling a bitmap
      * that will not result in the scaling past the desired dimensions.

--- a/Volley/src/main/java/com/volley/air/misc/MultipartUtils.java
+++ b/Volley/src/main/java/com/volley/air/misc/MultipartUtils.java
@@ -38,6 +38,12 @@ public class MultipartUtils {
 
     public static final byte[] CRLF_BYTES = EncodingUtils.getAsciiBytes(CRLF);
 
+    /**
+     * Prevents class instantiation
+     */
+    private MultipartUtils() {
+    }
+
     public static int getContentLengthForMultipartRequest(String boundary, Map<String, MultiPartRequest.MultiPartParam> multipartParams, Map<String, String> filesToUpload) {
         final int boundaryLength = boundary.getBytes().length;
         int contentLength = 0;

--- a/Volley/src/main/java/com/volley/air/misc/NetUtils.java
+++ b/Volley/src/main/java/com/volley/air/misc/NetUtils.java
@@ -24,6 +24,12 @@ import android.util.Log;
 public class NetUtils {
     private static final String TAG = "NetUtils";
     private static String mUserAgent = null;
+    
+    /**
+     * Prevents class instantiation
+     */
+    private NetUtils() {
+    }
 
     public static String getUserAgent(Context mContext) {
         if (mUserAgent == null) {

--- a/Volley/src/main/java/com/volley/air/toolbox/HttpHeaderParser.java
+++ b/Volley/src/main/java/com/volley/air/toolbox/HttpHeaderParser.java
@@ -34,6 +34,12 @@ import com.volley.air.base.NetworkResponse;
 public class HttpHeaderParser {
 
     /**
+     * Prevents class instantiation
+     */
+    private HttpHeaderParser() {
+    }
+
+    /**
      * Extracts a {@link Cache.Entry} from a {@link NetworkResponse}.
      *
      * @param response The network response to parse headers from

--- a/Volley/src/main/java/com/volley/air/toolbox/multipart/UrlEncodingHelper.java
+++ b/Volley/src/main/java/com/volley/air/toolbox/multipart/UrlEncodingHelper.java
@@ -7,6 +7,12 @@ import java.net.URLEncoder;
 
 public class UrlEncodingHelper {
 
+    /**
+     * Prevents class instantiation
+     */
+    private UrlEncodingHelper() {
+    }
+
     public static String encode(final String content, final String encoding) {
         try {
             return URLEncoder.encode(


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
