### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/Volley/src/main/java/com/volley/air/base/Request.java
+++ b/Volley/src/main/java/com/volley/air/base/Request.java
@@ -636,7 +636,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * @param response Response from the network
      * @return The parsed response, or null in the case of an error
      */
-    abstract protected Response<T> parseNetworkResponse(NetworkResponse response);
+    protected abstract Response<T> parseNetworkResponse(NetworkResponse response);
 
     /**
      * Subclasses can override this method to parse 'networkError' and return a more specific error.
@@ -657,7 +657,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * @param response The parsed response returned by
      * {@link #parseNetworkResponse(NetworkResponse)}
      */
-    abstract protected void deliverResponse(T response);
+    protected abstract void deliverResponse(T response);
 
     /**
      * Delivers error message to the ErrorListener that the Request was

--- a/Volley/src/main/java/com/volley/air/misc/AsyncTask.java
+++ b/Volley/src/main/java/com/volley/air/misc/AsyncTask.java
@@ -677,7 +677,7 @@ public abstract class AsyncTask<Params, Progress, Result> {
         }
     }
 
-    private static abstract class WorkerRunnable<Params, Result> implements Callable<Result> {
+    private abstract static class WorkerRunnable<Params, Result> implements Callable<Result> {
         Params[] mParams;
     }
 

--- a/Volley/src/main/java/com/volley/air/misc/ImageUtils.java
+++ b/Volley/src/main/java/com/volley/air/misc/ImageUtils.java
@@ -23,10 +23,10 @@ public class ImageUtils {
 
     /** Minimum class memory class to use full-res photos */
     @SuppressWarnings("unused")
-	private final static long MIN_NORMAL_CLASS = 32;
+    private static final long MIN_NORMAL_CLASS = 32;
     /** Minimum class memory class to use small photos */
     @SuppressWarnings("unused")
-	private final static long MIN_SMALL_CLASS = 24;
+    private static final long MIN_SMALL_CLASS = 24;
 
     private static final String BASE64_URI_PREFIX = "base64,";
     private static final Pattern BASE64_IMAGE_URI_PATTERN = Pattern.compile("^(?:.*;)?base64,.*");

--- a/Volley/src/main/java/com/volley/air/request/JsonRequest.java
+++ b/Volley/src/main/java/com/volley/air/request/JsonRequest.java
@@ -68,7 +68,7 @@ public abstract class JsonRequest<T> extends Request<T> {
     }
 
     @Override
-    abstract protected Response<T> parseNetworkResponse(NetworkResponse response);
+    protected abstract Response<T> parseNetworkResponse(NetworkResponse response);
 
     /**
      * @deprecated Use {@link #getBodyContentType()}.

--- a/Volley/src/main/java/com/volley/air/request/MultiPartRequest.java
+++ b/Volley/src/main/java/com/volley/air/request/MultiPartRequest.java
@@ -71,7 +71,7 @@ public abstract class MultiPartRequest<T> extends Request<T> implements Progress
 	}
 
 	@Override
-	abstract protected Response<T> parseNetworkResponse(NetworkResponse response);
+	protected abstract Response<T> parseNetworkResponse(NetworkResponse response);
 
 	@Override
 	protected void deliverResponse(T response) {

--- a/Volley/src/main/java/com/volley/air/toolbox/HttpClientStack.java
+++ b/Volley/src/main/java/com/volley/air/toolbox/HttpClientStack.java
@@ -58,7 +58,7 @@ public class HttpClientStack implements HttpStack {
 	protected final HttpClient mClient;
 
 	private static final String CONTENT_TYPE_MULTIPART = "multipart/form-data; charset=%s; boundary=%s";
-	private final static String HEADER_CONTENT_TYPE = "Content-Type";
+	private static final String HEADER_CONTENT_TYPE = "Content-Type";
 
 	public HttpClientStack(HttpClient client) {
 		mClient = client;
@@ -212,7 +212,7 @@ public class HttpClientStack implements HttpStack {
 	 */
 	public static final class HttpPatch extends HttpEntityEnclosingRequestBase {
 
-		public final static String METHOD_NAME = "PATCH";
+		public static final String METHOD_NAME = "PATCH";
 
 		public HttpPatch() {
 			super();

--- a/Volley/src/main/java/com/volley/air/toolbox/multipart/Boundary.java
+++ b/Volley/src/main/java/com/volley/air/toolbox/multipart/Boundary.java
@@ -14,7 +14,7 @@ import com.volley.air.misc.MultipartUtils;
 /* package */ class Boundary {
 
     /* The pool of ASCII chars to be used for generating a multipart boundary. */
-    private final static char[] MULTIPART_CHARS =
+    private static final char[] MULTIPART_CHARS =
             "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();   //$NON-NLS-1$
 
     private final String boundary;

--- a/Volley/src/main/java/com/volley/air/ui/PhotoView.java
+++ b/Volley/src/main/java/com/volley/air/ui/PhotoView.java
@@ -55,19 +55,19 @@ public class PhotoView extends NetworkImageView implements OnGestureListener,
         OnDoubleTapListener, ScaleGestureDetector.OnScaleGestureListener,
         HorizontallyScrollable {
     /** Zoom animation duration; in milliseconds */
-    private final static long ZOOM_ANIMATION_DURATION = 300L;
+    private static final long ZOOM_ANIMATION_DURATION = 300L;
     /** Rotate animation duration; in milliseconds */
-    private final static long ROTATE_ANIMATION_DURATION = 500L;
+    private static final long ROTATE_ANIMATION_DURATION = 500L;
     /** Snap animation duration; in milliseconds */
     private static final long SNAP_DURATION = 100L;
     /** Amount of time to wait before starting snap animation; in milliseconds */
     private static final long SNAP_DELAY = 250L;
     /** By how much to scale the image when double click occurs */
-    private final static float DOUBLE_TAP_SCALE_FACTOR = 1.5f;
+    private static final float DOUBLE_TAP_SCALE_FACTOR = 1.5f;
     /** Amount of translation needed before starting a snap animation */
-    private final static float SNAP_THRESHOLD = 20.0f;
+    private static final float SNAP_THRESHOLD = 20.0f;
     /** The width & height of the bitmap returned by {@link #getCroppedPhoto()} */
-    private final static float CROPPED_SIZE = 256.0f;
+    private static final float CROPPED_SIZE = 256.0f;
 
     /**
      * Touch slop used to determine if this double tap is valid for starting a scale or should be


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
