### PR TITLE
[squid:S2864] "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/Volley/src/main/java/com/volley/air/misc/MultipartUtils.java
+++ b/Volley/src/main/java/com/volley/air/misc/MultipartUtils.java
@@ -47,20 +47,20 @@ public class MultipartUtils {
     public static int getContentLengthForMultipartRequest(String boundary, Map<String, MultiPartRequest.MultiPartParam> multipartParams, Map<String, String> filesToUpload) {
         final int boundaryLength = boundary.getBytes().length;
         int contentLength = 0;
-        for (String key : multipartParams.keySet()) {
-            MultiPartRequest.MultiPartParam param = multipartParams.get(key);
+        for (Map.Entry<String, MultiPartRequest.MultiPartParam> entry : multipartParams.entrySet()) {
+            MultiPartRequest.MultiPartParam param = entry.getValue();
             int size = boundaryLength +
-                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA, key).getBytes().length +
+                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA, entry.getKey()).getBytes().length +
                     CRLF_LENGTH + HEADER_CONTENT_TYPE_LENGTH + COLON_SPACE_LENGTH + param.contentType.getBytes().length +
                     CRLF_LENGTH + CRLF_LENGTH + param.value.getBytes().length + CRLF_LENGTH;
 
             contentLength += size;
         }
 
-        for (String key : filesToUpload.keySet()) {
-            File file = new File(filesToUpload.get(key));
+        for (Map.Entry<String, String> entry : filesToUpload.entrySet()) {
+            File file = new File(entry.getValue());
             int size = boundaryLength +
-                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA + SEMICOLON_SPACE + FILENAME, key, file.getName()).getBytes().length +
+                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA + SEMICOLON_SPACE + FILENAME, entry.getKey(), file.getName()).getBytes().length +
                     CRLF_LENGTH + HEADER_CONTENT_TYPE_LENGTH + COLON_SPACE_LENGTH + CONTENT_TYPE_OCTET_STREAM_LENGTH +
                     CRLF_LENGTH + HEADER_CONTENT_TRANSFER_ENCODING_LENGTH + COLON_SPACE_LENGTH + BINARY_LENGTH + CRLF_LENGTH + CRLF_LENGTH;
 

--- a/Volley/src/main/java/com/volley/air/toolbox/HttpClientStack.java
+++ b/Volley/src/main/java/com/volley/air/toolbox/HttpClientStack.java
@@ -65,16 +65,16 @@ public class HttpClientStack implements HttpStack {
 	}
 
 	private static void addHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
-		for (String key : headers.keySet()) {
-			httpRequest.setHeader(key, headers.get(key));
+		for (Map.Entry<String, String> entry : headers.entrySet()) {
+			httpRequest.setHeader(entry.getKey(), entry.getValue());
 		}
 	}
 
 	@SuppressWarnings("unused")
 	private static List<NameValuePair> getPostParameterPairs(Map<String, String> postParams) {
 		List<NameValuePair> result = new ArrayList<>(postParams.size());
-		for (String key : postParams.keySet()) {
-			result.add(new BasicNameValuePair(key, postParams.get(key)));
+		for (Map.Entry<String, String> entry : postParams.entrySet()) {
+			result.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
 		}
 		return result;
 	}
@@ -165,12 +165,12 @@ public class HttpClientStack implements HttpStack {
 			final Map<String, MultiPartParam> multipartParams = ((MultiPartRequest<?>) request).getMultipartParams();
 			final Map<String, String> filesToUpload = ((MultiPartRequest<?>) request).getFilesToUpload();
 
-			for (String key : multipartParams.keySet()) {
-				multipartEntity.addPart(new StringPart(key, multipartParams.get(key).value));
+			for (Map.Entry<String, MultiPartParam> entry : multipartParams.entrySet()) {
+				multipartEntity.addPart(new StringPart(entry.getKey(), entry.getValue().value));
 			}
 
-			for (String key : filesToUpload.keySet()) {
-				File file = new File(filesToUpload.get(key));
+			for (Map.Entry<String, String> entry : filesToUpload.entrySet()) {
+				File file = new File(entry.getValue());
 
 				if (!file.exists()) {
 					throw new IOException(String.format("File not found: %s", file.getAbsolutePath()));
@@ -180,7 +180,7 @@ public class HttpClientStack implements HttpStack {
 					throw new IOException(String.format("File is a directory: %s", file.getAbsolutePath()));
 				}
 
-				FilePart filePart = new FilePart(key, file, null, null);
+				FilePart filePart = new FilePart(entry.getKey(), file, null, null);
 				multipartEntity.addPart(filePart);
 			}
 			httpRequest.setEntity(multipartEntity);

--- a/Volley/src/main/java/com/volley/air/toolbox/HurlStack.java
+++ b/Volley/src/main/java/com/volley/air/toolbox/HurlStack.java
@@ -149,8 +149,8 @@ public class HurlStack implements HttpStack {
 			connection.setRequestProperty(HEADER_USER_AGENT, mUserAgent);
 		}
 
-		for (String headerName : map.keySet()) {
-			connection.addRequestProperty(headerName, map.get(headerName));
+		for (Entry<String, String> entry : map.entrySet()) {
+			connection.addRequestProperty(entry.getKey(), entry.getValue());
 		}
 		if (request instanceof MultiPartRequest) {
 			setConnectionParametersForMultipartRequest(connection, request);
@@ -220,17 +220,17 @@ public class HurlStack implements HttpStack {
 			OutputStream out = connection.getOutputStream();
 			writer = new PrintWriter(new OutputStreamWriter(out, charset), true);
 
-			for (String key : multipartParams.keySet()) {
-				MultiPartParam param = multipartParams.get(key);
+			for (Entry<String, MultiPartParam> entry : multipartParams.entrySet()) {
+				MultiPartParam param = entry.getValue();
 
-				writer.append(boundary).append(CRLF).append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA, key)).append(CRLF)
+				writer.append(boundary).append(CRLF).append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA, entry.getKey())).append(CRLF)
 						.append(HEADER_CONTENT_TYPE + COLON_SPACE + param.contentType).append(CRLF).append(CRLF).append(param.value).append(CRLF)
 						.flush();
 			}
 
-			for (String key : filesToUpload.keySet()) {
+			for (Entry<String, String> entry : filesToUpload.entrySet()) {
 
-				File file = new File(filesToUpload.get(key));
+				File file = new File(entry.getValue());
 
 				if (!file.exists()) {
 					throw new IOException(String.format("File not found: %s", file.getAbsolutePath()));
@@ -242,7 +242,7 @@ public class HurlStack implements HttpStack {
 
 				writer.append(boundary)
 						.append(CRLF)
-						.append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA + SEMICOLON_SPACE + FILENAME, key, file.getName()))
+						.append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA + SEMICOLON_SPACE + FILENAME, entry.getKey(), file.getName()))
 						.append(CRLF).append(HEADER_CONTENT_TYPE + COLON_SPACE + CONTENT_TYPE_OCTET_STREAM).append(CRLF)
 						.append(HEADER_CONTENT_TRANSFER_ENCODING + COLON_SPACE + BINARY).append(CRLF).append(CRLF).flush();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.
Ayman Abdelghany.
